### PR TITLE
Fix the bug of overflow in AutoContrast

### DIFF
--- a/lavis/processors/randaugment.py
+++ b/lavis/processors/randaugment.py
@@ -23,6 +23,7 @@ def autocontrast_func(img, cutoff=0):
     n_bins = 256
 
     def tune_channel(ch):
+        ch = ch.astype(np.int16)
         n = ch.size
         cut = cutoff * n // 100
         if cut == 0:


### PR DESCRIPTION
## Bug description
Fix the bug of data overflow in `AutoContrast` function when applying `Randaugment`. See this [issue](https://github.com/salesforce/LAVIS/issues/434).

## Commit explanation
The root cause is the overflow caused by `np.uint8`. Specifically, in `L40` of the following code:
https://github.com/SCZwangxiao/LAVIS/blob/ac8fc98c93c02e2dfb727e24a361c4c309c8dbbc/lavis/processors/randaugment.py#L25-L45

where `ch` is one channel of an image (thus type `np.uint8`), and `low` is of type `np.uint8`. Therefore `offset = -low * scale` will cause an overflow since it cannot represent a negative number.

The reason why this bug did not affect much on the performance is: `low` is `0` most of the time.